### PR TITLE
feat: add automated file organization utilities for user folders

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,15 @@
-import { describe, it, expect } from 'vitest'
-import { sum, multiply } from './index'
+import { mkdtemp, mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { multiply, organizeCommonFolders, organizeFolder, sum } from './index'
+
+const temporaryFolders: string[] = []
+
+afterEach(async () => {
+  await Promise.all(temporaryFolders.map(folderPath => rm(folderPath, { recursive: true, force: true })))
+  temporaryFolders.length = 0
+})
 
 describe('Utility Functions', () => {
   describe('sum', () => {
@@ -34,6 +44,65 @@ describe('Utility Functions', () => {
     it('should handle zero', () => {
       expect(multiply(0, 5)).toBe(0)
       expect(multiply(7, 0)).toBe(0)
+    })
+  })
+
+  describe('organizeFolder', () => {
+    it('moves files into categorized folders and skips directories', async () => {
+      const workingFolder = await mkdtemp(join(tmpdir(), 'organize-folder-'))
+      temporaryFolders.push(workingFolder)
+
+      await writeFile(join(workingFolder, 'photo.jpg'), 'x')
+      await writeFile(join(workingFolder, 'notes.txt'), 'x')
+      await writeFile(join(workingFolder, 'archive.zip'), 'x')
+      await mkdir(join(workingFolder, 'keep-folder'))
+
+      const result = await organizeFolder(workingFolder)
+
+      expect(result.movedFiles).toBe(3)
+      expect(result.skippedFiles).toBe(1)
+
+      const imageStats = await stat(join(workingFolder, 'Images', 'photo.jpg'))
+      const documentStats = await stat(join(workingFolder, 'Documents', 'notes.txt'))
+      const archiveStats = await stat(join(workingFolder, 'Archives', 'archive.zip'))
+
+      expect(imageStats.isFile()).toBe(true)
+      expect(documentStats.isFile()).toBe(true)
+      expect(archiveStats.isFile()).toBe(true)
+    })
+
+    it('renames files when destination name already exists', async () => {
+      const workingFolder = await mkdtemp(join(tmpdir(), 'organize-collision-'))
+      temporaryFolders.push(workingFolder)
+
+      await mkdir(join(workingFolder, 'Documents'), { recursive: true })
+      await writeFile(join(workingFolder, 'Documents', 'notes.txt'), 'existing')
+      await writeFile(join(workingFolder, 'notes.txt'), 'incoming')
+
+      await organizeFolder(workingFolder)
+
+      const files = await readdir(join(workingFolder, 'Documents'))
+      expect(files.sort()).toEqual(['notes (1).txt', 'notes.txt'])
+    })
+  })
+
+  describe('organizeCommonFolders', () => {
+    it('organizes Downloads, Documents, and Desktop folders when present', async () => {
+      const homeFolder = await mkdtemp(join(tmpdir(), 'organize-home-'))
+      temporaryFolders.push(homeFolder)
+
+      await mkdir(join(homeFolder, 'Downloads'))
+      await mkdir(join(homeFolder, 'Desktop'))
+
+      await writeFile(join(homeFolder, 'Downloads', 'song.mp3'), 'x')
+      await writeFile(join(homeFolder, 'Desktop', 'movie.mp4'), 'x')
+
+      const result = await organizeCommonFolders(homeFolder)
+
+      expect(result.totalMoved).toBe(2)
+      expect(result.folders).toHaveLength(2)
+      await expect(stat(join(homeFolder, 'Downloads', 'Audio', 'song.mp3'))).resolves.toBeTruthy()
+      await expect(stat(join(homeFolder, 'Desktop', 'Videos', 'movie.mp4'))).resolves.toBeTruthy()
     })
   })
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+import { mkdir, readdir, rename, stat } from 'node:fs/promises'
+import { extname, join, parse } from 'node:path'
+
 /**
  * A simple utility function to add two numbers
  * @param a - First number
@@ -16,4 +19,136 @@ export function sum(a: number, b: number): number {
  */
 export function multiply(a: number, b: number): number {
   return a * b
+}
+
+const categoryByExtension: Record<string, string> = {
+  '.jpg': 'Images',
+  '.jpeg': 'Images',
+  '.png': 'Images',
+  '.gif': 'Images',
+  '.svg': 'Images',
+  '.webp': 'Images',
+  '.heic': 'Images',
+  '.pdf': 'Documents',
+  '.doc': 'Documents',
+  '.docx': 'Documents',
+  '.txt': 'Documents',
+  '.md': 'Documents',
+  '.rtf': 'Documents',
+  '.xls': 'Spreadsheets',
+  '.xlsx': 'Spreadsheets',
+  '.csv': 'Spreadsheets',
+  '.ppt': 'Presentations',
+  '.pptx': 'Presentations',
+  '.zip': 'Archives',
+  '.rar': 'Archives',
+  '.7z': 'Archives',
+  '.tar': 'Archives',
+  '.gz': 'Archives',
+  '.mp3': 'Audio',
+  '.wav': 'Audio',
+  '.m4a': 'Audio',
+  '.flac': 'Audio',
+  '.mp4': 'Videos',
+  '.mov': 'Videos',
+  '.mkv': 'Videos',
+  '.avi': 'Videos',
+  '.exe': 'Applications',
+  '.dmg': 'Applications',
+  '.pkg': 'Applications',
+  '.msi': 'Applications',
+}
+
+export interface OrganizeFolderResult {
+  folder: string
+  movedFiles: number
+  skippedFiles: number
+}
+
+export interface OrganizeResult {
+  folders: OrganizeFolderResult[]
+  totalMoved: number
+  totalSkipped: number
+}
+
+async function getUniqueFilePath(targetFilePath: string): Promise<string> {
+  let candidate = targetFilePath
+  let counter = 1
+
+  while (true) {
+    try {
+      await stat(candidate)
+      const parsed = parse(targetFilePath)
+      candidate = join(parsed.dir, `${parsed.name} (${counter})${parsed.ext}`)
+      counter += 1
+    } catch {
+      return candidate
+    }
+  }
+}
+
+function getCategoryName(fileName: string): string {
+  const extension = extname(fileName).toLowerCase()
+  return categoryByExtension[extension] ?? 'Other'
+}
+
+export async function organizeFolder(folderPath: string): Promise<OrganizeFolderResult> {
+  const entries = await readdir(folderPath)
+  let movedFiles = 0
+  let skippedFiles = 0
+
+  for (const entry of entries) {
+    const sourcePath = join(folderPath, entry)
+    const sourceStats = await stat(sourcePath)
+
+    if (!sourceStats.isFile()) {
+      skippedFiles += 1
+      continue
+    }
+
+    const categoryName = getCategoryName(entry)
+    const targetDirectoryPath = join(folderPath, categoryName)
+
+    await mkdir(targetDirectoryPath, { recursive: true })
+
+    const targetPath = await getUniqueFilePath(join(targetDirectoryPath, entry))
+    await rename(sourcePath, targetPath)
+    movedFiles += 1
+  }
+
+  return {
+    folder: folderPath,
+    movedFiles,
+    skippedFiles,
+  }
+}
+
+export async function organizeCommonFolders(basePath: string): Promise<OrganizeResult> {
+  const userFolders = ['Downloads', 'Documents', 'Desktop']
+  const folders: OrganizeFolderResult[] = []
+
+  for (const folderName of userFolders) {
+    const folderPath = join(basePath, folderName)
+
+    try {
+      const folderStats = await stat(folderPath)
+      if (!folderStats.isDirectory()) {
+        continue
+      }
+    } catch {
+      continue
+    }
+
+    const result = await organizeFolder(folderPath)
+    folders.push(result)
+  }
+
+  const totalMoved = folders.reduce((sumValue, result) => sumValue + result.movedFiles, 0)
+  const totalSkipped = folders.reduce((sumValue, result) => sumValue + result.skippedFiles, 0)
+
+  return {
+    folders,
+    totalMoved,
+    totalSkipped,
+  }
 }


### PR DESCRIPTION
### Motivation
- Provide an automated utility to declutter common user folders by categorizing files by extension (Images, Documents, Archives, Audio, Videos, Applications, and fallback `Other`).
- Ensure safe moves so existing files are not overwritten and duplicates are preserved with a predictable rename scheme.

### Description
- Add an extension-to-category map in `src/index.ts` and the helper `getCategoryName` to determine destination folders for files. 
- Implement `organizeFolder(folderPath)` which moves files into category subfolders, skips non-file entries, and returns moved/skipped counts. 
- Add collision-safe naming via `getUniqueFilePath` that produces `name (1).ext`, `name (2).ext`, etc., to avoid overwriting existing files. 
- Add `organizeCommonFolders(basePath)` to run `organizeFolder` on `Downloads`, `Documents`, and `Desktop` when they exist, and add tests in `src/index.test.ts` covering categorization, skips, collisions, and common-folder orchestration. 

### Testing
- Ran `npm test` which completed successfully (all tests passed: 9 tests) and reported coverage for `index.ts` at ~98.19%. 
- Ran `npm run type-check` which completed with no TypeScript errors. 
- Ran `npm run lint -- --ignore-pattern coverage` which completed with no reported lint errors after ignoring coverage output files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ec4a6665848331adcccec2e9f6db61)