### PR TITLE
Add placeholder city council campaign site

### DIFF
--- a/campaign-site/README.md
+++ b/campaign-site/README.md
@@ -1,0 +1,48 @@
+# Campaign Site — Placeholder
+
+A static dummy campaign website modeled after the structure of edreece.com, built for a fictional candidate **Jordan Rivera for Westbrook City Council**. All names, quotes, endorsers, events, and contact info are placeholders.
+
+## Run locally
+
+No build step — open `index.html` directly, or serve the folder:
+
+```bash
+cd campaign-site
+python3 -m http.server 8000
+# then visit http://localhost:8000
+```
+
+## Files
+
+- `index.html` — full single-page site
+- `styles.css` — visual system (navy + gold, serif headings, sans body)
+- `script.js` — mobile nav, donate amount selection, mock form handlers
+
+## Sections (in order)
+
+1. Sticky header + nav with Donate CTA
+2. Hero — tagline, headline, candidate pull-quote, photo, CTAs
+3. Credential strip (5 role bullets)
+4. Email signup with ZIP capture
+5. Priorities grid — "Back to Basics" (6 tiles)
+6. Endorsements (grid + "see all" link)
+7. About Jordan (photo + long-form bio)
+8. Story / podcast feature
+9. Upcoming events
+10. Donate + Volunteer side-by-side cards
+11. Contact form + socials
+12. Footer with "Paid for by…" disclosure
+
+## How to swap in real content
+
+All copy lives in `index.html`. Search for these placeholders:
+
+- `Jordan Rivera` — candidate name
+- `Westbrook` — city
+- `District 3` — office
+- `Rivera & Co.` — business
+- Endorser names inside `.endorser-grid`
+- Event dates and venues inside `.events-list`
+- Disclosure / FPPC ID in the footer
+
+For the visual style, edit the `:root` color tokens at the top of `styles.css`.

--- a/campaign-site/index.html
+++ b/campaign-site/index.html
@@ -1,0 +1,455 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Jordan Rivera for Westbrook City Council</title>
+    <meta
+      name="description"
+      content="Jordan Rivera is running for Westbrook City Council. Safer streets, smarter spending, stronger neighborhoods."
+    />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,500;9..144,700;9..144,800&family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#main">Skip to content</a>
+
+    <header class="site-header">
+      <div class="container nav">
+        <a class="brand" href="#top" aria-label="Jordan Rivera for City Council">
+          <span class="brand-mark">JR</span>
+          <span class="brand-text">
+            <strong>Jordan Rivera</strong>
+            <em>for Westbrook City Council</em>
+          </span>
+        </a>
+
+        <button
+          class="nav-toggle"
+          aria-expanded="false"
+          aria-controls="primary-nav"
+          aria-label="Toggle menu"
+        >
+          <span></span><span></span><span></span>
+        </button>
+
+        <nav id="primary-nav" class="primary-nav" aria-label="Primary">
+          <a href="#priorities">Priorities</a>
+          <a href="#about">About Jordan</a>
+          <a href="#endorsements">Endorsements</a>
+          <a href="#events">Events</a>
+          <a href="#contact">Contact</a>
+          <a class="btn btn-primary nav-cta" href="#donate">Donate</a>
+        </nav>
+      </div>
+    </header>
+
+    <main id="main">
+      <!-- HERO -->
+      <section id="top" class="hero">
+        <div class="container hero-grid">
+          <div class="hero-copy">
+            <p class="eyebrow">Keeping Westbrook Safe, Strong, and Thriving</p>
+            <h1>Focused leadership.<br />Proven results.<br />A clear plan for what's next.</h1>
+            <blockquote class="hero-quote">
+              <p>
+                "My priority is simple: keep our neighborhoods safe, protect property values, and
+                deliver the services our residents rely on every single day. Together, we will
+                ensure that Westbrook always remains a great place to live, work, and raise a
+                family."
+              </p>
+              <cite>— Jordan Rivera, Council Member, District 3</cite>
+            </blockquote>
+            <div class="hero-ctas">
+              <a class="btn btn-primary" href="#donate">Donate</a>
+              <a class="btn btn-secondary" href="#volunteer">Volunteer</a>
+              <a class="btn btn-ghost" href="#priorities">See the Plan →</a>
+            </div>
+          </div>
+          <div class="hero-photo" aria-hidden="true">
+            <div class="photo-frame">
+              <div class="photo-placeholder">
+                <span>Candidate Photo</span>
+                <small>900 × 1100</small>
+              </div>
+            </div>
+            <div class="photo-caption">Jordan with family at Westbrook City Hall</div>
+          </div>
+        </div>
+      </section>
+
+      <!-- CREDENTIAL STRIP -->
+      <section class="credentials" aria-label="Credentials">
+        <div class="container creds-grid">
+          <div class="cred">
+            <span class="cred-verb">Serving</span>
+            <span class="cred-text">Westbrook as Council Member, District 3</span>
+          </div>
+          <div class="cred">
+            <span class="cred-verb">Leading</span>
+            <span class="cred-text">the region as Metro Planning Vice Chair</span>
+          </div>
+          <div class="cred">
+            <span class="cred-verb">Delivering</span>
+            <span class="cred-text">results as Public Safety Committee Chair</span>
+          </div>
+          <div class="cred">
+            <span class="cred-verb">Advocating</span>
+            <span class="cred-text">in the Capitol as League of Cities Delegate</span>
+          </div>
+          <div class="cred">
+            <span class="cred-verb">Built</span>
+            <span class="cred-text">a 22-year local small business from the ground up</span>
+          </div>
+        </div>
+      </section>
+
+      <!-- EMAIL SIGNUP -->
+      <section class="email-bar" aria-label="Stay in touch">
+        <div class="container email-grid">
+          <div class="email-copy">
+            <h2>Join the campaign</h2>
+            <p>Get updates on events, endorsements, and how to help Westbrook win.</p>
+          </div>
+          <form class="email-form" data-form="email">
+            <label class="visually-hidden" for="email-input">Email</label>
+            <input
+              type="email"
+              id="email-input"
+              name="email"
+              required
+              placeholder="you@email.com"
+            />
+            <input
+              type="text"
+              name="zip"
+              required
+              maxlength="5"
+              pattern="[0-9]{5}"
+              placeholder="ZIP"
+              inputmode="numeric"
+              aria-label="ZIP code"
+            />
+            <button type="submit" class="btn btn-primary">Sign Up</button>
+          </form>
+        </div>
+      </section>
+
+      <!-- PRIORITIES -->
+      <section id="priorities" class="priorities">
+        <div class="container">
+          <header class="section-head">
+            <p class="eyebrow">Council Priorities</p>
+            <h2>Back to Basics</h2>
+            <p class="lede">
+              The city's first job is to master its essential mandates. Jordan will refocus
+              Westbrook on the core services that affect your property values, your safety, and
+              your quality of life.
+            </p>
+          </header>
+
+          <div class="priority-grid">
+            <article class="priority-card">
+              <div class="icon" aria-hidden="true">🛡️</div>
+              <h3>Public Safety First</h3>
+              <p>
+                Fully staff the police and fire departments, expand community policing, and shorten
+                emergency response times across every district.
+              </p>
+              <a href="#" class="card-link">Read more →</a>
+            </article>
+            <article class="priority-card">
+              <div class="icon" aria-hidden="true">🏘️</div>
+              <h3>Protect Property Values</h3>
+              <p>
+                Enforce neighborhood standards, fix the streets and sidewalks we already have, and
+                stop unfunded mandates that drive up your tax bill.
+              </p>
+              <a href="#" class="card-link">Read more →</a>
+            </article>
+            <article class="priority-card">
+              <div class="icon" aria-hidden="true">💼</div>
+              <h3>Support Local Business</h3>
+              <p>
+                Cut red tape for small businesses, fill empty storefronts on Main Street, and bring
+                good jobs to Westbrook residents.
+              </p>
+              <a href="#" class="card-link">Read more →</a>
+            </article>
+            <article class="priority-card">
+              <div class="icon" aria-hidden="true">🚆</div>
+              <h3>Smarter Transit & Roads</h3>
+              <p>
+                Finish the Eastside Corridor, repave 50 miles of neighborhood streets, and demand
+                our region's fair share of state and federal dollars.
+              </p>
+              <a href="#" class="card-link">Read more →</a>
+            </article>
+            <article class="priority-card">
+              <div class="icon" aria-hidden="true">📊</div>
+              <h3>Responsible Budgeting</h3>
+              <p>
+                Audit every line item, protect the reserve fund, and stop sweetheart contracts that
+                waste your tax dollars.
+              </p>
+              <a href="#" class="card-link">Read more →</a>
+            </article>
+            <article class="priority-card">
+              <div class="icon" aria-hidden="true">🌳</div>
+              <h3>Parks & Open Space</h3>
+              <p>
+                Maintain the parks we have, finish the Greenway extension, and keep Westbrook a
+                place where kids can play outside and families can breathe.
+              </p>
+              <a href="#" class="card-link">Read more →</a>
+            </article>
+          </div>
+        </div>
+      </section>
+
+      <!-- ENDORSEMENTS -->
+      <section id="endorsements" class="endorsements">
+        <div class="container">
+          <header class="section-head center">
+            <p class="eyebrow">Endorsed by Community Leaders</p>
+            <h2>Westbrook is with Jordan</h2>
+          </header>
+          <ul class="endorser-grid">
+            <li><strong>Mayor Patricia Ng</strong><span>City of Westbrook</span></li>
+            <li><strong>Senator Marcus Hale</strong><span>State District 14</span></li>
+            <li><strong>Sheriff Dana Whitfield</strong><span>Lincoln County</span></li>
+            <li><strong>Westbrook Firefighters Local 412</strong><span>Public Safety</span></li>
+            <li><strong>Chamber of Commerce</strong><span>Business Community</span></li>
+            <li><strong>Teachers Association</strong><span>Westbrook Schools</span></li>
+            <li><strong>Rev. Eleanor Park</strong><span>First Community Church</span></li>
+            <li><strong>Realtors Association</strong><span>Greater Westbrook</span></li>
+          </ul>
+          <p class="center">
+            <a href="#" class="btn btn-ghost">See all 120+ endorsements →</a>
+          </p>
+        </div>
+      </section>
+
+      <!-- ABOUT -->
+      <section id="about" class="about">
+        <div class="container about-grid">
+          <div class="about-photo" aria-hidden="true">
+            <div class="photo-placeholder square">
+              <span>About Photo</span>
+              <small>800 × 800</small>
+            </div>
+          </div>
+          <div class="about-copy">
+            <p class="eyebrow">22-Year Small Business Owner & Civic Leader</p>
+            <h2>About Jordan</h2>
+            <p>
+              Jordan Rivera is serving a second term on the Westbrook City Council. Over those four
+              years, Jordan has worked to raise Westbrook's profile in the areas of public safety,
+              regional transit, and small-business growth.
+            </p>
+            <p>
+              Jordan is the founder of Rivera & Co., a Westbrook-based marketing firm started out
+              of a spare bedroom and grown over 22 years to a team of eighteen. The Westbrook
+              Chamber of Commerce named Jordan its Business Person of the Year in 2019, and the
+              State Legislature has recognized the firm's work mentoring first-generation
+              entrepreneurs.
+            </p>
+            <p>
+              Jordan got into civic life in the early 2010s, first as a member of the Westbrook
+              Police Commission and later as Co-Chair of Partners for a Safer Westbrook. As a
+              cancer survivor and lifelong volunteer, Jordan has served on the boards of the
+              Westbrook Community Foundation and the Eastside Youth Theater.
+            </p>
+            <p>
+              Jordan previously served as Mayor Pro Tem (2023–2024) and lives in the Maple Heights
+              neighborhood with spouse Alex and their two kids, Sam and Theo.
+            </p>
+            <p><a class="btn btn-ghost" href="#">Read the full biography →</a></p>
+          </div>
+        </div>
+      </section>
+
+      <!-- STORY / PODCAST -->
+      <section class="story">
+        <div class="container story-grid">
+          <div class="story-copy">
+            <p class="eyebrow">The Interview</p>
+            <h2>"Never Give Up"</h2>
+            <p>
+              A long-form conversation with Riley Chen of the Westbrook Speaks podcast. Jordan
+              recounts the hurdles, the setbacks, and the moments that shaped who Jordan is today —
+              from a first failed small business to a cancer diagnosis at 38.
+            </p>
+            <a class="btn btn-primary" href="#">Listen now →</a>
+          </div>
+          <div class="story-media" aria-hidden="true">
+            <div class="photo-placeholder wide">
+              <span>Podcast Cover / Video Thumbnail</span>
+              <small>16:9</small>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- EVENTS -->
+      <section id="events" class="events">
+        <div class="container">
+          <header class="section-head">
+            <p class="eyebrow">Coming Up</p>
+            <h2>Meet Jordan in the Neighborhood</h2>
+          </header>
+          <ul class="events-list">
+            <li>
+              <time datetime="2026-06-04"><span>JUN</span><strong>04</strong></time>
+              <div>
+                <h3>Coffee with Jordan — Maple Heights</h3>
+                <p>Saturday · 9:00 AM · Beans & Books, 412 Maple Ave</p>
+              </div>
+              <a href="#" class="btn btn-secondary">RSVP</a>
+            </li>
+            <li>
+              <time datetime="2026-06-12"><span>JUN</span><strong>12</strong></time>
+              <div>
+                <h3>Public Safety Town Hall</h3>
+                <p>Sunday · 4:00 PM · Westbrook Community Center, Hall B</p>
+              </div>
+              <a href="#" class="btn btn-secondary">RSVP</a>
+            </li>
+            <li>
+              <time datetime="2026-06-22"><span>JUN</span><strong>22</strong></time>
+              <div>
+                <h3>Neighborhood Walk — Eastside</h3>
+                <p>Wednesday · 6:00 PM · Meet at Eastside Park gazebo</p>
+              </div>
+              <a href="#" class="btn btn-secondary">RSVP</a>
+            </li>
+          </ul>
+        </div>
+      </section>
+
+      <!-- GET INVOLVED / DONATE / VOLUNTEER -->
+      <section id="donate" class="get-involved">
+        <div class="container involved-grid">
+          <article class="involved-card" id="donate-card">
+            <h3>Donate</h3>
+            <p>
+              Every dollar funds yard signs, mailers, and the door-knocking that wins races at the
+              city-council level.
+            </p>
+            <div class="amounts">
+              <button type="button">$25</button>
+              <button type="button">$50</button>
+              <button type="button">$100</button>
+              <button type="button">$250</button>
+              <button type="button">Other</button>
+            </div>
+            <a href="#" class="btn btn-primary block">Contribute Now</a>
+          </article>
+
+          <article class="involved-card" id="volunteer">
+            <h3>Volunteer</h3>
+            <p>Knock doors, make calls, host a meet-and-greet, or drop a sign in your yard.</p>
+            <form class="volunteer-form" data-form="volunteer">
+              <label>
+                <span class="visually-hidden">Name</span>
+                <input type="text" name="name" placeholder="Full name" required />
+              </label>
+              <label>
+                <span class="visually-hidden">Email</span>
+                <input type="email" name="email" placeholder="Email" required />
+              </label>
+              <fieldset>
+                <legend>I want to:</legend>
+                <label><input type="checkbox" name="role" value="canvass" /> Knock doors</label>
+                <label><input type="checkbox" name="role" value="phone" /> Make calls</label>
+                <label><input type="checkbox" name="role" value="sign" /> Put up a yard sign</label>
+                <label><input type="checkbox" name="role" value="host" /> Host an event</label>
+              </fieldset>
+              <button type="submit" class="btn btn-secondary block">Sign Me Up</button>
+            </form>
+          </article>
+        </div>
+      </section>
+
+      <!-- CONTACT -->
+      <section id="contact" class="contact">
+        <div class="container contact-grid">
+          <div class="contact-copy">
+            <p class="eyebrow">Contact</p>
+            <h2>Reach Out</h2>
+            <p>
+              Have a question, a concern, or an idea for Westbrook? Send a note and the campaign
+              will get back to you within two business days.
+            </p>
+            <ul class="contact-meta">
+              <li><strong>Email:</strong> hello@riveraforwestbrook.example</li>
+              <li><strong>Phone:</strong> (555) 010-2034</li>
+              <li><strong>HQ:</strong> 218 Main Street, Westbrook</li>
+            </ul>
+            <div class="socials" aria-label="Follow Jordan">
+              <a href="#" aria-label="Facebook">FB</a>
+              <a href="#" aria-label="Instagram">IG</a>
+              <a href="#" aria-label="X">X</a>
+              <a href="#" aria-label="YouTube">YT</a>
+              <a href="#" aria-label="LinkedIn">IN</a>
+            </div>
+          </div>
+          <form class="contact-form" data-form="contact">
+            <label>
+              <span>Name</span>
+              <input type="text" name="name" required />
+            </label>
+            <label>
+              <span>Email</span>
+              <input type="email" name="email" required />
+            </label>
+            <label>
+              <span>Subject</span>
+              <input type="text" name="subject" />
+            </label>
+            <label>
+              <span>Message</span>
+              <textarea name="message" rows="5" required></textarea>
+            </label>
+            <button type="submit" class="btn btn-primary">Submit</button>
+            <p class="form-success" hidden>Thanks for submitting — we'll be in touch.</p>
+          </form>
+        </div>
+      </section>
+    </main>
+
+    <footer class="site-footer">
+      <div class="container footer-grid">
+        <div>
+          <div class="brand brand-footer">
+            <span class="brand-mark">JR</span>
+            <span class="brand-text">
+              <strong>Jordan Rivera</strong>
+              <em>for Westbrook City Council</em>
+            </span>
+          </div>
+          <p class="disclosure">
+            Paid for by Rivera for Westbrook 2026. FPPC ID #1234567. Not authorized by any
+            candidate or committee for federal office.
+          </p>
+        </div>
+        <nav aria-label="Footer">
+          <a href="#priorities">Priorities</a>
+          <a href="#about">About</a>
+          <a href="#endorsements">Endorsements</a>
+          <a href="#events">Events</a>
+          <a href="#donate">Donate</a>
+          <a href="#contact">Contact</a>
+        </nav>
+        <p class="copy">© 2026 Rivera for Westbrook. All rights reserved.</p>
+      </div>
+    </footer>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/campaign-site/script.js
+++ b/campaign-site/script.js
@@ -1,0 +1,46 @@
+// Mobile nav toggle
+const navToggle = document.querySelector('.nav-toggle');
+const primaryNav = document.getElementById('primary-nav');
+
+if (navToggle && primaryNav) {
+  navToggle.addEventListener('click', () => {
+    const open = primaryNav.classList.toggle('open');
+    navToggle.setAttribute('aria-expanded', open ? 'true' : 'false');
+  });
+
+  primaryNav.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', () => {
+      primaryNav.classList.remove('open');
+      navToggle.setAttribute('aria-expanded', 'false');
+    });
+  });
+}
+
+// Donate amount selection
+const amountButtons = document.querySelectorAll('.amounts button');
+amountButtons.forEach((btn) => {
+  btn.addEventListener('click', () => {
+    amountButtons.forEach((b) => b.classList.remove('selected'));
+    btn.classList.add('selected');
+  });
+});
+
+// Mock form handling — no real backend
+document.querySelectorAll('form[data-form]').forEach((form) => {
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    const success = form.querySelector('.form-success');
+    if (success) {
+      success.hidden = false;
+    } else {
+      const note = document.createElement('p');
+      note.className = 'form-success';
+      note.textContent = 'Thanks — placeholder form, no data was submitted.';
+      form.appendChild(note);
+    }
+    form.querySelectorAll('input, textarea').forEach((el) => {
+      if (el.type !== 'submit' && el.type !== 'button') el.value = '';
+    });
+    form.querySelectorAll('input[type="checkbox"]').forEach((el) => (el.checked = false));
+  });
+});

--- a/campaign-site/styles.css
+++ b/campaign-site/styles.css
@@ -1,0 +1,1052 @@
+/* ---------- Tokens ---------- */
+:root {
+  --navy: #0b2545;
+  --navy-2: #13315c;
+  --ink: #0f172a;
+  --paper: #ffffff;
+  --cream: #f7f3ec;
+  --line: #e6e1d6;
+  --muted: #5b6473;
+  --gold: #c8a14a;
+  --gold-2: #b08e3a;
+  --red: #b3261e;
+  --shadow: 0 6px 20px rgba(11, 37, 69, 0.08);
+  --radius: 14px;
+  --container: 1180px;
+  --serif: 'Fraunces', Georgia, 'Times New Roman', serif;
+  --sans: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+/* ---------- Reset ---------- */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: var(--sans);
+  font-size: 17px;
+  line-height: 1.6;
+  color: var(--ink);
+  background: var(--paper);
+  -webkit-font-smoothing: antialiased;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  font-family: var(--serif);
+  font-weight: 700;
+  color: var(--navy);
+  letter-spacing: -0.01em;
+  margin: 0 0 0.5em;
+  line-height: 1.15;
+}
+
+h1 {
+  font-size: clamp(2.2rem, 5vw, 3.6rem);
+}
+
+h2 {
+  font-size: clamp(1.7rem, 3.2vw, 2.4rem);
+}
+
+h3 {
+  font-size: 1.2rem;
+}
+
+p {
+  margin: 0 0 1em;
+}
+
+a {
+  color: var(--navy);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--gold-2);
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+.container {
+  max-width: var(--container);
+  margin: 0 auto;
+  padding: 0 22px;
+}
+
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.skip-link {
+  position: absolute;
+  left: -9999px;
+}
+
+.skip-link:focus {
+  left: 12px;
+  top: 12px;
+  background: var(--navy);
+  color: #fff;
+  padding: 8px 12px;
+  border-radius: 6px;
+  z-index: 100;
+}
+
+/* ---------- Buttons ---------- */
+.btn {
+  display: inline-block;
+  font-weight: 600;
+  font-size: 0.95rem;
+  padding: 12px 22px;
+  border-radius: 999px;
+  border: 2px solid transparent;
+  cursor: pointer;
+  transition:
+    transform 0.08s ease,
+    background 0.15s ease,
+    color 0.15s ease,
+    border-color 0.15s ease;
+  text-align: center;
+}
+
+.btn:active {
+  transform: translateY(1px);
+}
+
+.btn-primary {
+  background: var(--gold);
+  color: var(--navy);
+  border-color: var(--gold);
+}
+
+.btn-primary:hover {
+  background: var(--gold-2);
+  border-color: var(--gold-2);
+  color: var(--navy);
+}
+
+.btn-secondary {
+  background: var(--navy);
+  color: #fff;
+  border-color: var(--navy);
+}
+
+.btn-secondary:hover {
+  background: var(--navy-2);
+  border-color: var(--navy-2);
+  color: #fff;
+}
+
+.btn-ghost {
+  background: transparent;
+  color: var(--navy);
+  border-color: var(--navy);
+}
+
+.btn-ghost:hover {
+  background: var(--navy);
+  color: #fff;
+}
+
+.btn.block {
+  display: block;
+  width: 100%;
+}
+
+/* ---------- Header / Nav ---------- */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(255, 255, 255, 0.94);
+  backdrop-filter: saturate(140%) blur(6px);
+  border-bottom: 1px solid var(--line);
+}
+
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  height: 72px;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  color: var(--navy);
+}
+
+.brand-mark {
+  display: grid;
+  place-items: center;
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  background: var(--navy);
+  color: var(--gold);
+  font-family: var(--serif);
+  font-weight: 800;
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+}
+
+.brand-text {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.1;
+}
+
+.brand-text strong {
+  font-family: var(--serif);
+  font-weight: 700;
+  font-size: 1.1rem;
+}
+
+.brand-text em {
+  font-style: normal;
+  font-size: 0.78rem;
+  color: var(--muted);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.primary-nav {
+  display: flex;
+  align-items: center;
+  gap: 26px;
+}
+
+.primary-nav a {
+  font-weight: 500;
+  font-size: 0.95rem;
+  color: var(--ink);
+}
+
+.primary-nav a:hover {
+  color: var(--gold-2);
+}
+
+.nav-cta {
+  padding: 9px 18px;
+  font-size: 0.9rem;
+}
+
+.nav-toggle {
+  display: none;
+  background: none;
+  border: 0;
+  width: 40px;
+  height: 40px;
+  position: relative;
+  cursor: pointer;
+}
+
+.nav-toggle span {
+  position: absolute;
+  left: 9px;
+  right: 9px;
+  height: 2px;
+  background: var(--navy);
+  transition: transform 0.2s ease;
+}
+
+.nav-toggle span:nth-child(1) {
+  top: 14px;
+}
+.nav-toggle span:nth-child(2) {
+  top: 19px;
+}
+.nav-toggle span:nth-child(3) {
+  top: 24px;
+}
+
+@media (max-width: 880px) {
+  .nav-toggle {
+    display: block;
+  }
+  .primary-nav {
+    position: absolute;
+    top: 72px;
+    left: 0;
+    right: 0;
+    flex-direction: column;
+    background: #fff;
+    border-bottom: 1px solid var(--line);
+    padding: 18px 22px 22px;
+    gap: 14px;
+    align-items: stretch;
+    display: none;
+  }
+  .primary-nav.open {
+    display: flex;
+  }
+  .nav-cta {
+    text-align: center;
+  }
+}
+
+/* ---------- Hero ---------- */
+.hero {
+  background:
+    radial-gradient(1200px 600px at 80% -10%, rgba(200, 161, 74, 0.18), transparent 60%),
+    linear-gradient(180deg, #fbf8f2 0%, #f4ede0 100%);
+  padding: 64px 0 72px;
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: 1.15fr 0.85fr;
+  gap: 56px;
+  align-items: center;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--gold-2);
+  margin: 0 0 14px;
+}
+
+.hero h1 {
+  margin-bottom: 24px;
+}
+
+.hero-quote {
+  margin: 0 0 28px;
+  padding: 18px 22px;
+  border-left: 3px solid var(--gold);
+  background: rgba(255, 255, 255, 0.6);
+  border-radius: 0 var(--radius) var(--radius) 0;
+  font-style: italic;
+  color: var(--ink);
+}
+
+.hero-quote p {
+  margin: 0 0 10px;
+}
+
+.hero-quote cite {
+  font-style: normal;
+  font-weight: 600;
+  color: var(--navy);
+  font-size: 0.95rem;
+}
+
+.hero-ctas {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.photo-frame {
+  position: relative;
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: var(--shadow);
+}
+
+.photo-placeholder {
+  aspect-ratio: 9 / 11;
+  background:
+    repeating-linear-gradient(
+      45deg,
+      rgba(11, 37, 69, 0.08),
+      rgba(11, 37, 69, 0.08) 12px,
+      rgba(11, 37, 69, 0.04) 12px,
+      rgba(11, 37, 69, 0.04) 24px
+    ),
+    var(--navy);
+  color: #fff;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
+.photo-placeholder small {
+  display: block;
+  opacity: 0.7;
+  font-weight: 500;
+  margin-top: 6px;
+}
+
+.photo-placeholder.square {
+  aspect-ratio: 1 / 1;
+}
+
+.photo-placeholder.wide {
+  aspect-ratio: 16 / 9;
+}
+
+.photo-caption {
+  margin-top: 10px;
+  font-size: 0.85rem;
+  color: var(--muted);
+  text-align: center;
+  font-style: italic;
+}
+
+@media (max-width: 880px) {
+  .hero-grid {
+    grid-template-columns: 1fr;
+    gap: 36px;
+  }
+}
+
+/* ---------- Credentials strip ---------- */
+.credentials {
+  background: var(--navy);
+  color: #fff;
+  padding: 22px 0;
+}
+
+.creds-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 22px;
+}
+
+.cred {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 0.92rem;
+  line-height: 1.4;
+}
+
+.cred-verb {
+  color: var(--gold);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.78rem;
+}
+
+.cred-text {
+  color: rgba(255, 255, 255, 0.9);
+}
+
+@media (max-width: 980px) {
+  .creds-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 540px) {
+  .creds-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---------- Email bar ---------- */
+.email-bar {
+  background: var(--cream);
+  border-bottom: 1px solid var(--line);
+  padding: 40px 0;
+}
+
+.email-grid {
+  display: grid;
+  grid-template-columns: 1fr 1.2fr;
+  align-items: center;
+  gap: 32px;
+}
+
+.email-copy h2 {
+  margin: 0 0 4px;
+  font-size: 1.6rem;
+}
+
+.email-copy p {
+  margin: 0;
+  color: var(--muted);
+}
+
+.email-form {
+  display: grid;
+  grid-template-columns: 2fr 1fr auto;
+  gap: 10px;
+}
+
+.email-form input {
+  padding: 12px 14px;
+  border-radius: 10px;
+  border: 1px solid var(--line);
+  font: inherit;
+  background: #fff;
+}
+
+.email-form input:focus {
+  outline: 2px solid var(--gold);
+  outline-offset: 1px;
+  border-color: var(--gold);
+}
+
+@media (max-width: 720px) {
+  .email-grid {
+    grid-template-columns: 1fr;
+  }
+  .email-form {
+    grid-template-columns: 1fr 1fr;
+  }
+  .email-form button {
+    grid-column: span 2;
+  }
+}
+
+/* ---------- Section heads ---------- */
+.section-head {
+  max-width: 760px;
+  margin: 0 0 36px;
+}
+
+.section-head.center {
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+}
+
+.section-head .lede {
+  font-size: 1.1rem;
+  color: var(--muted);
+}
+
+.priorities,
+.endorsements,
+.about,
+.story,
+.events,
+.get-involved,
+.contact {
+  padding: 88px 0;
+}
+
+/* ---------- Priorities ---------- */
+.priority-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 22px;
+}
+
+.priority-card {
+  background: var(--cream);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 26px 24px;
+  transition:
+    transform 0.15s ease,
+    box-shadow 0.2s ease;
+}
+
+.priority-card:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--shadow);
+}
+
+.priority-card .icon {
+  font-size: 1.6rem;
+  margin-bottom: 10px;
+}
+
+.priority-card h3 {
+  font-size: 1.2rem;
+  margin-bottom: 8px;
+}
+
+.priority-card p {
+  color: var(--muted);
+  font-size: 0.96rem;
+  margin-bottom: 12px;
+}
+
+.card-link {
+  font-weight: 600;
+  font-size: 0.92rem;
+  color: var(--navy);
+  border-bottom: 1px solid var(--gold);
+  padding-bottom: 1px;
+}
+
+.card-link:hover {
+  color: var(--gold-2);
+}
+
+@media (max-width: 900px) {
+  .priority-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 560px) {
+  .priority-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---------- Endorsements ---------- */
+.endorsements {
+  background: var(--navy);
+  color: #fff;
+}
+
+.endorsements .section-head h2,
+.endorsements .section-head .eyebrow {
+  color: #fff;
+}
+
+.endorsements .section-head .eyebrow {
+  color: var(--gold);
+}
+
+.endorser-grid {
+  list-style: none;
+  margin: 0 0 28px;
+  padding: 0;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 16px;
+}
+
+.endorser-grid li {
+  background: rgba(255, 255, 255, 0.06);
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  padding: 18px 16px;
+  border-radius: var(--radius);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.endorser-grid strong {
+  font-family: var(--serif);
+  font-size: 1.05rem;
+  color: #fff;
+}
+
+.endorser-grid span {
+  font-size: 0.82rem;
+  color: rgba(255, 255, 255, 0.7);
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.endorsements .btn-ghost {
+  color: #fff;
+  border-color: rgba(255, 255, 255, 0.5);
+}
+
+.endorsements .btn-ghost:hover {
+  background: #fff;
+  color: var(--navy);
+}
+
+.center {
+  text-align: center;
+}
+
+@media (max-width: 900px) {
+  .endorser-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 520px) {
+  .endorser-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---------- About ---------- */
+.about {
+  background: #fff;
+}
+
+.about-grid {
+  display: grid;
+  grid-template-columns: 0.9fr 1.1fr;
+  gap: 56px;
+  align-items: center;
+}
+
+.about-copy p {
+  color: var(--ink);
+}
+
+@media (max-width: 880px) {
+  .about-grid {
+    grid-template-columns: 1fr;
+    gap: 32px;
+  }
+}
+
+/* ---------- Story / Podcast ---------- */
+.story {
+  background: var(--cream);
+}
+
+.story-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 48px;
+  align-items: center;
+}
+
+@media (max-width: 880px) {
+  .story-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---------- Events ---------- */
+.events {
+  background: #fff;
+}
+
+.events-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.events-list li {
+  display: grid;
+  grid-template-columns: 90px 1fr auto;
+  align-items: center;
+  gap: 22px;
+  padding: 20px 22px;
+  background: var(--cream);
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+}
+
+.events-list time {
+  background: var(--navy);
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  border-radius: 10px;
+  padding: 10px 0;
+}
+
+.events-list time span {
+  font-size: 0.75rem;
+  letter-spacing: 0.14em;
+  color: var(--gold);
+  font-weight: 700;
+}
+
+.events-list time strong {
+  font-family: var(--serif);
+  font-size: 1.6rem;
+  line-height: 1;
+}
+
+.events-list h3 {
+  margin: 0 0 4px;
+  font-size: 1.1rem;
+}
+
+.events-list p {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.92rem;
+}
+
+@media (max-width: 640px) {
+  .events-list li {
+    grid-template-columns: 70px 1fr;
+  }
+  .events-list .btn {
+    grid-column: span 2;
+    justify-self: start;
+  }
+}
+
+/* ---------- Get Involved (donate + volunteer) ---------- */
+.get-involved {
+  background: var(--cream);
+}
+
+.involved-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 24px;
+}
+
+.involved-card {
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: var(--radius);
+  padding: 32px;
+  box-shadow: var(--shadow);
+}
+
+.involved-card h3 {
+  font-size: 1.5rem;
+  margin-bottom: 6px;
+}
+
+.involved-card > p {
+  color: var(--muted);
+  margin-bottom: 18px;
+}
+
+.amounts {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 8px;
+  margin-bottom: 18px;
+}
+
+.amounts button {
+  padding: 12px 0;
+  border-radius: 10px;
+  background: var(--cream);
+  border: 1px solid var(--line);
+  font: inherit;
+  font-weight: 600;
+  color: var(--navy);
+  cursor: pointer;
+  transition:
+    background 0.15s,
+    border-color 0.15s,
+    color 0.15s;
+}
+
+.amounts button:hover,
+.amounts button.selected {
+  background: var(--navy);
+  border-color: var(--navy);
+  color: var(--gold);
+}
+
+.volunteer-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.volunteer-form input {
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  font: inherit;
+}
+
+.volunteer-form fieldset {
+  border: 0;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px 16px;
+}
+
+.volunteer-form legend {
+  font-weight: 600;
+  margin-bottom: 6px;
+  color: var(--navy);
+}
+
+.volunteer-form label {
+  font-size: 0.95rem;
+}
+
+@media (max-width: 760px) {
+  .involved-grid {
+    grid-template-columns: 1fr;
+  }
+  .amounts {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+/* ---------- Contact ---------- */
+.contact {
+  background: #fff;
+}
+
+.contact-grid {
+  display: grid;
+  grid-template-columns: 1fr 1.1fr;
+  gap: 56px;
+  align-items: start;
+}
+
+.contact-meta {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 18px;
+}
+
+.contact-meta li {
+  margin: 4px 0;
+  color: var(--ink);
+}
+
+.socials {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.socials a {
+  display: grid;
+  place-items: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: var(--cream);
+  border: 1px solid var(--line);
+  color: var(--navy);
+  font-weight: 700;
+  font-size: 0.78rem;
+}
+
+.socials a:hover {
+  background: var(--navy);
+  color: var(--gold);
+}
+
+.contact-form {
+  display: grid;
+  gap: 14px;
+}
+
+.contact-form label {
+  display: grid;
+  gap: 6px;
+  font-weight: 600;
+  font-size: 0.92rem;
+  color: var(--navy);
+}
+
+.contact-form input,
+.contact-form textarea {
+  font: inherit;
+  padding: 12px 14px;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  background: #fff;
+}
+
+.contact-form input:focus,
+.contact-form textarea:focus {
+  outline: 2px solid var(--gold);
+  outline-offset: 1px;
+  border-color: var(--gold);
+}
+
+.form-success {
+  background: #e8f4ea;
+  border: 1px solid #b9d9bf;
+  color: #1f5132;
+  border-radius: 10px;
+  padding: 12px 14px;
+  font-weight: 600;
+}
+
+@media (max-width: 880px) {
+  .contact-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---------- Footer ---------- */
+.site-footer {
+  background: var(--ink);
+  color: #d8dde6;
+  padding: 48px 0 36px;
+}
+
+.footer-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr;
+  gap: 24px;
+  align-items: start;
+}
+
+.brand-footer .brand-text strong {
+  color: #fff;
+}
+
+.brand-footer .brand-text em {
+  color: #aab3c0;
+}
+
+.brand-footer .brand-mark {
+  background: #fff;
+  color: var(--navy);
+}
+
+.site-footer nav {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.site-footer nav a {
+  color: #d8dde6;
+  font-size: 0.95rem;
+}
+
+.site-footer nav a:hover {
+  color: var(--gold);
+}
+
+.disclosure {
+  font-size: 0.82rem;
+  color: #aab3c0;
+  margin-top: 16px;
+  max-width: 460px;
+  line-height: 1.5;
+}
+
+.copy {
+  font-size: 0.8rem;
+  color: #aab3c0;
+  margin: 0;
+  align-self: end;
+  text-align: right;
+}
+
+@media (max-width: 760px) {
+  .footer-grid {
+    grid-template-columns: 1fr;
+  }
+  .copy {
+    text-align: left;
+  }
+}


### PR DESCRIPTION
## Summary

- New `campaign-site/` static site (HTML/CSS/JS) modeled after the structure of edreece.com, intended as a scaffold for a real city-council campaign site.
- Placeholder candidate: **Jordan Rivera for Westbrook City Council, District 3**. All names, quotes, endorsers, events, and contact info are fake.

## Sections included

- Sticky header + nav with Donate CTA
- Hero (tagline, headline, candidate pull-quote, photo, CTAs)
- Credential strip (5 role bullets)
- Email signup with ZIP capture
- "Back to Basics" priorities grid (6 tiles)
- Endorsements grid
- About (long-form bio)
- Story / podcast feature
- Upcoming events list
- Donate + Volunteer cards
- Contact form + socials
- Footer with "Paid for by…" disclosure

## How to preview

```bash
cd campaign-site
python3 -m http.server 8000
# http://localhost:8000
```

## Swapping in real content

All copy lives in `index.html`. Visual tokens (colors, fonts) live at the top of `styles.css` under `:root`. See `campaign-site/README.md` for details.

## Test plan

- [ ] Open `index.html` in a browser; verify sections render top-to-bottom
- [ ] Resize to mobile width; confirm nav toggle, grid collapse, form layout
- [ ] Submit each form; confirm placeholder success message
- [ ] Click donate amount buttons; confirm selected state


---
_Generated by [Claude Code](https://claude.ai/code/session_016BQvzXdetQjFi4TXruo16d)_